### PR TITLE
Add dark admin panel base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Dark Admin Panel
+
+This repository contains a minimal dark-mode admin panel prototype with PWA support.
+
+## Getting Started
+
+Open `index.html` in a modern browser. The service worker provides offline caching, and the layout adapts responsively from mobile to desktop.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#000" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="stylesheet" href="style.css" />
+  <title>Dark Admin Panel</title>
+</head>
+<body>
+  <header class="app-header">
+    <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <h1 class="app-title">Admin Panel</h1>
+  </header>
+  <nav id="sidebar" class="sidebar">
+    <ul>
+      <li><a href="#">Dashboard</a></li>
+      <li><a href="#">Settings</a></li>
+    </ul>
+  </nav>
+  <main id="main" class="main-content">
+    <h2>Welcome</h2>
+    <p>This is a minimal dark-mode admin panel skeleton.</p>
+  </main>
+  <footer class="app-footer">v0.1</footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Dark Admin Panel",
+  "short_name": "Admin",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#000000",
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,14 @@
+(function () {
+  const toggle = document.getElementById('nav-toggle');
+  const sidebar = document.getElementById('sidebar');
+
+  toggle.addEventListener('click', () => {
+    sidebar.classList.toggle('open');
+  });
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('service-worker.js');
+    });
+  }
+})();

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'admin-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,89 @@
+:root {
+  --bg-color: #000;
+  --text-color: #fff;
+  --accent-color: #1e90ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  background: #111;
+}
+
+.app-title {
+  margin: 0;
+  flex: 1;
+  text-align: center;
+}
+
+#nav-toggle {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 1.5rem;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: -250px;
+  width: 200px;
+  height: 100%;
+  background: #111;
+  overflow-y: auto;
+  transition: left 0.3s ease;
+}
+
+.sidebar.open {
+  left: 0;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+}
+
+.sidebar li {
+  padding: 1rem;
+}
+
+.sidebar a {
+  color: var(--text-color);
+  text-decoration: none;
+}
+
+.main-content {
+  margin-left: 0;
+  padding: 1rem;
+}
+
+@media (min-width: 600px) {
+  .main-content {
+    margin-left: 200px;
+  }
+  .sidebar {
+    left: 0;
+  }
+}
+
+.app-footer {
+  margin-top: auto;
+  text-align: center;
+  padding: 1rem;
+  background: #111;
+}


### PR DESCRIPTION
## Summary
- add minimal index.html with header, sidebar, and footer
- style with CSS variables and responsive layout
- implement sidebar toggle and service worker registration
- include manifest.json and service worker for PWA
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68419b83e1a8833189341bc08ea9adc2