### PR TITLE
Improve header with reusable script

### DIFF
--- a/header-checklist.md
+++ b/header-checklist.md
@@ -1,0 +1,8 @@
+# Header Improvement Checklist
+
+- [x] Move repeated header markup into a reusable script (`header.js`).
+- [x] Add a "skip to main content" link in the header.
+- [x] Ensure header uses flexbox spacing and adapts on small screens.
+- [x] Relocate dark/light mode toggle exclusively to the Settings page.
+- [x] Use inline SVG icons to reduce external icon requests.
+- [x] Replace ID-based header styles with CSS classes.

--- a/header.js
+++ b/header.js
@@ -1,0 +1,20 @@
+(function () {
+  window.buildHeader = function (title, opts = {}) {
+    const header = document.createElement('header');
+    header.className = 'app-header';
+    header.setAttribute('role', 'banner');
+    header.innerHTML = `
+      <a href="#main" class="skip-link">Skip to content</a>
+      <button class="nav-toggle" aria-label="Open navigation" aria-controls="sidebar"></button>
+      <h1 class="app-title">${title}</h1>
+    `;
+    if (opts.themeToggle) {
+      const themeBtn = document.createElement('button');
+      themeBtn.className = 'theme-toggle';
+      themeBtn.setAttribute('aria-label', 'Toggle dark mode');
+      themeBtn.innerHTML = `<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 0 18 9 9 0 0 1 0-18z" fill="currentColor"/></svg>`;
+      header.appendChild(themeBtn);
+    }
+    document.body.prepend(header);
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -9,11 +9,8 @@
   <title>Dark Admin Panel</title>
 </head>
 <body>
-  <header class="app-header" role="banner">
-    <h1 class="app-title">Admin Panel</h1>
-    <button id="nav-toggle" aria-label="Open navigation" aria-controls="sidebar">☰</button>
-    <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
-  </header>
+  <script src="header.js"></script>
+  <script>buildHeader('Admin Panel');</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>

--- a/reports.html
+++ b/reports.html
@@ -9,11 +9,8 @@
   <title>Reports</title>
 </head>
 <body>
-  <header class="app-header" role="banner">
-    <h1 class="app-title">Reports</h1>
-    <button id="nav-toggle" aria-label="Open navigation" aria-controls="sidebar">☰</button>
-    <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
-  </header>
+  <script src="header.js"></script>
+  <script>buildHeader('Reports');</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,8 @@
 (function () {
-  const toggle = document.getElementById('nav-toggle');
+  const toggle = document.querySelector('.nav-toggle');
   const sidebar = document.getElementById('sidebar');
   const overlay = document.getElementById('overlay');
-  const themeToggle = document.getElementById('theme-toggle');
+  const themeToggle = document.querySelector('.theme-toggle');
   const closeBtn = document.getElementById('sidebar-close');
   const firstLink = sidebar ? sidebar.querySelector('a') : null;
   let initialLoad = true;
@@ -26,14 +26,14 @@
   const updateToggle = () => {
     const isOpen = sidebar.classList.contains('open');
     if (isOpen) {
-      toggle.textContent = '✖';
+      toggle.innerHTML = '<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>';
       toggle.setAttribute('aria-label', 'Close navigation');
       toggle.setAttribute('aria-expanded', 'true');
       overlay.classList.add('visible');
       localStorage.setItem('sidebarOpen', 'true');
       if (!initialLoad && firstLink) firstLink.focus();
     } else {
-      toggle.textContent = '☰';
+      toggle.innerHTML = '<svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>';
       toggle.setAttribute('aria-label', 'Open navigation');
       toggle.setAttribute('aria-expanded', 'false');
       overlay.classList.remove('visible');
@@ -87,13 +87,15 @@
     });
   });
 
-  themeToggle.addEventListener('click', () => {
-    document.body.classList.toggle('light');
-    localStorage.setItem(
-      'theme',
-      document.body.classList.contains('light') ? 'light' : 'dark'
-    );
-  });
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('light');
+      localStorage.setItem(
+        'theme',
+        document.body.classList.contains('light') ? 'light' : 'dark'
+      );
+    });
+  }
 
   if (tableSkeleton && userTable) {
     setTimeout(() => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,7 +5,8 @@ const ASSETS = [
   '/settings.html',
   '/reports.html',
   '/style.css',
-  '/script.js'
+  '/script.js',
+  '/header.js'
 ];
 
 self.addEventListener('install', event => {

--- a/settings.html
+++ b/settings.html
@@ -9,11 +9,8 @@
   <title>Settings</title>
 </head>
 <body>
-  <header class="app-header" role="banner">
-    <h1 class="app-title">Settings</h1>
-    <button id="nav-toggle" aria-label="Open navigation" aria-controls="sidebar">☰</button>
-    <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
-  </header>
+  <script src="header.js"></script>
+  <script>buildHeader('Settings', {themeToggle: true});</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>

--- a/style.css
+++ b/style.css
@@ -23,6 +23,20 @@ body {
   min-height: 100vh;
 }
 
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background: var(--accent-color);
+  color: #fff;
+  padding: 0.5rem;
+  z-index: 100;
+}
+
+.skip-link:focus {
+  left: 0;
+}
+
 .app-header {
   display: flex;
   align-items: center;
@@ -37,7 +51,7 @@ body {
   text-align: center;
 }
 
-#nav-toggle {
+.nav-toggle {
   background: none;
   border: none;
   color: var(--text-color);
@@ -45,7 +59,7 @@ body {
   margin-left: auto;
 }
 
-#theme-toggle {
+.theme-toggle {
   background: none;
   border: none;
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- add `header.js` and checklist documenting header improvements
- implement header creation script with skip link and optional theme toggle
- switch header elements from IDs to classes and move theme toggle to settings only
- adjust CSS for new classes and add skip-link styles
- update pages to use the script-generated header
- cache new asset in service worker

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684210ddf7c4833195bcc0cc5e7f54da