### PR TITLE
Add loader checklist

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -15,3 +15,13 @@
 - [x] Ensure the skeleton width adapts with the table on narrow screens for better responsiveness.
 - [x] Trigger skeleton removal after real data is fetched rather than a fixed `setTimeout` to improve perceived performance.
 - [x] Document the loading logic in `pages-plan.md` to assist future maintenance.
+
+## Improvement Checklist — Component: Sidebar Link Loader
+- [x] Extract loader markup into a dedicated overlay element and include it on all pages.
+- [x] Provide showLoader() and hideLoader() functions in `script.js` to keep logic centralized.
+- [x] Add `role="status"` and `aria-live="polite"` to the loader so screen readers announce loading state.
+- [x] Ensure the loader overlay covers the viewport and centers the spinner responsively on mobile and desktop.
+- [x] Fade the loader in/out to maintain consistent UX when navigating between pages.
+- [x] Keep CSS animation lightweight to minimize layout thrashing and improve performance.
+- [x] Document usage of the loader in `pages-plan.md` for maintainability.
+

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
+  <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">
+    <div class="spinner" aria-hidden="true"></div>
+    <span class="sr-only">Loading...</span>
+  </div>
   <main id="main" class="main-content" role="main">
     <h2>Welcome</h2>
     <p>This is a minimal dark-mode admin panel skeleton.</p>

--- a/pages-plan.md
+++ b/pages-plan.md
@@ -22,6 +22,10 @@ This document outlines suggested content and improvements for each page in the a
 - [x] Chart.js graphs summarizing visitor data.
 - [x] Options to switch between different report ranges.
 
+## Loader Overlay
+- The `page-loader` element shows a spinner during page transitions.
+- Call `showLoader()` before navigation and `hideLoader()` once the new page has loaded.
+
 ## Future Pages
 - **User Management** – dedicated page for adding or suspending users.
 - **Analytics** – deeper insights with multiple charts and export options.

--- a/reports.html
+++ b/reports.html
@@ -20,6 +20,10 @@
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
+  <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">
+    <div class="spinner" aria-hidden="true"></div>
+    <span class="sr-only">Loading...</span>
+  </div>
   <main id="main" class="main-content" role="main">
     <h2>Reports</h2>
     <label for="report-range" class="sr-only">Select range</label>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@
   const overlay = document.getElementById('overlay');
   const themeToggle = document.querySelector('.theme-toggle');
   const closeBtn = document.getElementById('sidebar-close');
+  const pageLoader = document.getElementById('page-loader');
   const firstLink = sidebar ? sidebar.querySelector('a') : null;
   let initialLoad = true;
   const tableSkeleton = document.querySelector('.table-skeleton');
@@ -12,6 +13,16 @@
   const form = document.getElementById('settings-form');
   const toast = document.getElementById('toast');
   const chartCanvas = document.getElementById('reportChart');
+
+  window.showLoader = function () {
+    if (pageLoader) pageLoader.classList.add('visible');
+  };
+
+  window.hideLoader = function () {
+    if (pageLoader) pageLoader.classList.remove('visible');
+  };
+
+  hideLoader();
 
   const applyTheme = () => {
     const saved = localStorage.getItem('theme');
@@ -84,6 +95,7 @@
     link.addEventListener('click', () => {
       sidebar.classList.remove('open');
       updateToggle();
+      showLoader();
     });
   });
 

--- a/settings.html
+++ b/settings.html
@@ -20,6 +20,10 @@
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
+  <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">
+    <div class="spinner" aria-hidden="true"></div>
+    <span class="sr-only">Loading...</span>
+  </div>
   <main id="main" class="main-content" role="main">
     <h2>Settings</h2>
     <form id="settings-form">

--- a/style.css
+++ b/style.css
@@ -298,3 +298,38 @@ button:focus {
     transition: none;
   }
 }
+
+.page-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 30;
+}
+
+.page-loader.visible {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.page-loader .spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid transparent;
+  border-top-color: var(--text-color);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- outline improvements for adding a loader when navigating via the sidebar
- implement a global page-loader overlay with show/hide helpers
- update documentation to describe loader usage

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68423374f8848331a8e548ce215877a6