### PR TITLE
Fix settings header initialization

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -9,8 +9,8 @@
   <title>Settings</title>
 </head>
 <body>
-  <script src="header.min.js" defer></script>
-  <script defer>buildHeader('Settings', {themeToggle: true});</script>
+  <script src="header.min.js"></script>
+  <script>buildHeader('Settings', {themeToggle: true});</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>


### PR DESCRIPTION
## Summary
- fix call order for `buildHeader` on the settings page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68427b16ad948331b2bdfac8473c2e35