### PR TITLE
Fix service worker caching error

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'admin-cache-v1';
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/settings.html',
-  '/reports.html',
-  '/style.css',
-  '/script.js',
-  '/header.js'
+  './',
+  './index.html',
+  './settings.html',
+  './reports.html',
+  './style.css',
+  './script.js',
+  './header.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- use relative paths for cached assets so installation succeeds even in subfolders

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68428dc034448331a426a4cb28b4cfa9