### PR TITLE
Improve .btn focus ring styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,6 +196,12 @@ body {
   cursor: pointer;
 }
 
+/* Visible focus ring for keyboard users */
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--bg-color), 0 0 0 6px var(--accent-color);
+}
+
 .label {
   padding: 0.2rem 0.4rem;
   border-radius: 3px;


### PR DESCRIPTION
## Summary
- add custom focus ring to `.btn` elements for better keyboard visibility

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842df4fdc308331814e277d9da4144b