### PR TITLE
Add modal support

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
     <div class="spinner" aria-hidden="true"></div>
     <span class="sr-only">Loading...</span>
   </div>
+  <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
     <h2>Welcome</h2>
     <p>This is a minimal dark-mode admin panel skeleton.</p>

--- a/reports.html
+++ b/reports.html
@@ -32,6 +32,7 @@
     <div class="spinner" aria-hidden="true"></div>
     <span class="sr-only">Loading...</span>
   </div>
+  <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
     <h2>Reports</h2>
     <label for="report-range" class="sr-only">Select range</label>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@
   const moonIcon = '<svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
   const closeBtn = document.getElementById('sidebar-close');
   const pageLoader = document.getElementById('page-loader');
+  const modal = document.getElementById('modal');
   const firstLink = sidebar ? sidebar.querySelector('a') : null;
   let initialLoad = true;
   const tableSkeleton = document.querySelector('.table-skeleton');
@@ -26,6 +27,61 @@
   };
 
   hideLoader();
+
+  let lastFocused;
+  const focusableSelector =
+    'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+  function handleKey(e) {
+    if (e.key === 'Escape') {
+      closeModal();
+      return;
+    }
+    if (e.key === 'Tab') {
+      const focusable = modal.querySelectorAll(focusableSelector);
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  function outsideClick(e) {
+    if (e.target === modal) closeModal();
+  }
+
+  function openModal(html) {
+    if (!modal) return;
+    lastFocused = document.activeElement;
+    modal.innerHTML = '<div class="modal-content">' + html + '</div>';
+    modal.classList.add('visible');
+    modal.setAttribute('aria-hidden', 'false');
+    const focusable = modal.querySelectorAll(focusableSelector);
+    if (focusable[0]) focusable[0].focus();
+    modal.addEventListener('click', outsideClick);
+    document.addEventListener('keydown', handleKey);
+  }
+
+  function closeModal() {
+    if (!modal) return;
+    modal.classList.remove('visible');
+    modal.setAttribute('aria-hidden', 'true');
+    modal.innerHTML = '';
+    modal.removeEventListener('click', outsideClick);
+    document.removeEventListener('keydown', handleKey);
+    if (lastFocused) lastFocused.focus();
+  }
+
+  window.openModal = openModal;
+  window.closeModal = closeModal;
 
   const applyTheme = () => {
     const saved = localStorage.getItem('theme');

--- a/settings.html
+++ b/settings.html
@@ -24,6 +24,7 @@
     <div class="spinner" aria-hidden="true"></div>
     <span class="sr-only">Loading...</span>
   </div>
+  <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
     <h2>Settings</h2>
     <form id="settings-form">

--- a/style.css
+++ b/style.css
@@ -342,6 +342,32 @@ html.light .filter-input {
   animation: spin 0.8s linear infinite;
 }
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 40;
+}
+
+.modal.visible {
+  display: flex;
+}
+
+.modal .modal-content {
+  background: var(--surface-color);
+  padding: 1.5rem;
+  border-radius: 4px;
+  max-width: 90%;
+  max-height: 90%;
+  overflow: auto;
+}
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary
- insert modal container in HTML files
- style modal overlay and content
- add openModal/closeModal helpers in script

## Testing
- `node -c script.js` *(fails: option not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6842e2c07904833186df3a96cf060316