### PR TITLE
Add modal editing for users

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@
         <tr>
           <td>Alice</td>
           <td><span class="label success">Active</span></td>
-          <td><button class="btn">Edit</button></td>
+          <td><button class="btn edit-user-btn">Edit</button></td>
         </tr>
         <tr>
           <td>Bob</td>
           <td><span class="label danger">Suspended</span></td>
-          <td><button class="btn">Edit</button></td>
+          <td><button class="btn edit-user-btn">Edit</button></td>
         </tr>
       </tbody>
     </table>

--- a/script.js
+++ b/script.js
@@ -219,6 +219,51 @@
     if (filterInput) {
       filterInput.addEventListener('input', filterRows);
     }
+
+    tbody.querySelectorAll('.edit-user-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const row = btn.closest('tr');
+        const username = row.children[0].textContent.trim();
+        const status = row.querySelector('td:nth-child(2) .label').textContent.trim();
+        const html = `
+          <form id="edit-user-form">
+            <h3>Edit User</h3>
+            <label>Username
+              <input id="edit-username" type="text" value="${username}" required />
+            </label>
+            <label>Status
+              <select id="edit-status">
+                <option value="Active"${status === 'Active' ? ' selected' : ''}>Active</option>
+                <option value="Suspended"${status === 'Suspended' ? ' selected' : ''}>Suspended</option>
+              </select>
+            </label>
+            <div class="modal-actions">
+              <button type="submit" class="btn">Save</button>
+              <button type="button" class="btn" id="cancel-edit">Cancel</button>
+            </div>
+          </form>`;
+
+        openModal(html);
+
+        const form = document.getElementById('edit-user-form');
+        const cancel = document.getElementById('cancel-edit');
+
+        form.addEventListener('submit', (e) => {
+          e.preventDefault();
+          row.children[0].textContent = document.getElementById('edit-username').value;
+          const newStatus = document.getElementById('edit-status').value;
+          const label = row.querySelector('td:nth-child(2) .label');
+          label.textContent = newStatus;
+          label.classList.toggle('success', newStatus === 'Active');
+          label.classList.toggle('danger', newStatus !== 'Active');
+          closeModal();
+        });
+
+        cancel.addEventListener('click', () => {
+          closeModal();
+        });
+      });
+    });
   };
 
   if (chartCanvas && window.Chart) {


### PR DESCRIPTION
## Summary
- mark each Edit button with `edit-user-btn` class
- open a modal form when editing a user
- allow saving or cancelling to close the modal

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842e4a160388331bccc6c2ab3b713df