### PR TITLE
Add sidebar notification badge style

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <ul>
       <li><a href="index.html" class="active"><span class="icon">🏠</span>Dashboard</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
-      <li><a href="reports.html"><span class="icon">📊</span>Reports</a></li>
+      <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>

--- a/reports.html
+++ b/reports.html
@@ -24,7 +24,7 @@
     <ul>
       <li><a href="index.html"><span class="icon">🏠</span>Dashboard</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
-      <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports</a></li>
+      <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>

--- a/settings.html
+++ b/settings.html
@@ -16,7 +16,7 @@
     <ul>
       <li><a href="index.html"><span class="icon" aria-hidden="true">🏠</span>Dashboard</a></li>
       <li><a href="settings.html" class="active"><span class="icon" aria-hidden="true">⚙️</span>Settings</a></li>
-      <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports</a></li>
+      <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>

--- a/style.css
+++ b/style.css
@@ -216,6 +216,18 @@ body {
   background: #c0392b;
 }
 
+.badge {
+  display: inline-block;
+  min-width: 1rem;
+  padding: 0.2rem;
+  border-radius: 999px;
+  background: var(--accent-color);
+  color: #fff;
+  line-height: 1;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
 a:focus,
 button:focus {
   outline: 2px solid var(--accent-color);


### PR DESCRIPTION
## Summary
- style small numeric badges in the stylesheet
- display badge example next to the Reports link on all pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842e8514ee08331a1f2302e5074594d