### PR TITLE
Add alt-row styling and sticky table headers

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,11 +181,22 @@ body {
   margin-top: 1rem;
 }
 
+/* Sticky headers keep column names visible during scroll */
   .data-table th,
   .data-table td {
     padding: 0.5rem;
     border: 1px solid var(--border-color);
     text-align: left;
+  }
+
+  .data-table th {
+    position: sticky;
+    top: 0;
+  }
+
+/* Alternate row background for better readability */
+  .data-table tr:nth-child(even) {
+    background: var(--surface-alt-color);
   }
 
 .btn {


### PR DESCRIPTION
## Summary
- add sticky header styles for `.data-table`
- alternate row backgrounds for improved readability

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea8a70648331bedc9af9753eb903