### PR TITLE
Add analytics page with charts

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#000" />
   <link rel="manifest" href="manifest.json" />
   <script>
@@ -14,20 +14,20 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css" />
-  <title>Reports</title>
+  <title>Analytics</title>
 </head>
 <body>
   <script src="header.min.js"></script>
-  <script>buildHeader('Reports');</script>
+  <script>buildHeader('Analytics');</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>
       <li><a href="index.html"><span class="icon">🏠</span>Dashboard</a></li>
       <li><a href="users.html"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
-      <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
-      <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
-</ul>
+      <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
+      <li><a href="analytics.html" class="active"><span class="icon">📈</span>Analytics</a></li>
+    </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">
@@ -36,14 +36,14 @@
   </div>
   <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
-    <h2>Reports</h2>
-    <label for="report-range" class="sr-only">Select range</label>
-    <select id="report-range">
-      <option value="month">This month</option>
-      <option value="week">This week</option>
-      <option value="year">This year</option>
-    </select>
-    <canvas id="reportChart" width="400" height="200"></canvas>
+    <h2>Analytics</h2>
+    <div class="date-range">
+      <label>From <input type="date" id="start-date"></label>
+      <label>To <input type="date" id="end-date"></label>
+      <button id="apply-range" class="btn">Apply</button>
+    </div>
+    <canvas id="visitorsChart" width="400" height="200"></canvas>
+    <canvas id="sourceChart" width="300" height="200"></canvas>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <footer class="app-footer" role="contentinfo">v0.1</footer>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
       <li><a href="users.html"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
-    </ul>
+      <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+</ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">

--- a/pages-plan.md
+++ b/pages-plan.md
@@ -28,12 +28,15 @@ This document outlines suggested content and improvements for each page in the a
 - [x] Reuses table sorting and filtering from the dashboard.
 - [x] Modal forms manage user details.
 
+## Analytics (analytics.html)
+- [x] Line and pie charts powered by Chart.js.
+- [x] Date range picker updates both charts on apply.
+
 ## Loader Overlay
 - The `page-loader` element shows a spinner during page transitions.
 - Call `showLoader()` before navigation and `hideLoader()` once the new page has loaded.
 
 ## Future Pages
-- **Analytics** – deeper insights with multiple charts and export options.
 - **Profile** – personal account settings and password changes.
 
 These plans build on the existing checklist and keep the overall dark theme while adding more robust features.

--- a/script.js
+++ b/script.js
@@ -361,6 +361,60 @@
     }
   }
 
+  const visitorsCanvas = document.getElementById('visitorsChart');
+  const sourceCanvas = document.getElementById('sourceChart');
+  const startInput = document.getElementById('start-date');
+  const endInput = document.getElementById('end-date');
+  const applyBtn = document.getElementById('apply-range');
+  let visitorsChart, sourceChart;
+  if (visitorsCanvas && sourceCanvas && window.Chart) {
+    visitorsChart = new Chart(visitorsCanvas.getContext('2d'), {
+      type: 'line',
+      data: {
+        labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+        datasets: [{
+          label: 'Visitors',
+          borderColor: '#3498db',
+          fill: false,
+          data: [5, 7, 6, 4, 3, 2, 8]
+        }]
+      },
+      options: { responsive: true }
+    });
+    sourceChart = new Chart(sourceCanvas.getContext('2d'), {
+      type: 'pie',
+      data: {
+        labels: ['Direct', 'Referral', 'Social'],
+        datasets: [{
+          backgroundColor: ['#3498db', '#9b59b6', '#e74c3c'],
+          data: [50, 30, 20]
+        }]
+      },
+      options: { responsive: true }
+    });
+  }
+
+  window.updateAnalyticsCharts = function () {
+    if (!visitorsChart || !sourceChart) return;
+    const start = startInput.value ? new Date(startInput.value) : null;
+    const end = endInput.value ? new Date(endInput.value) : null;
+    const diff = start && end ? Math.floor((end - start) / 86400000) : 0;
+    if (diff >= 30) {
+      visitorsChart.data.labels = ['Week 1', 'Week 2', 'Week 3', 'Week 4'];
+      visitorsChart.data.datasets[0].data = [10, 12, 8, 15];
+      sourceChart.data.datasets[0].data = [40, 35, 25];
+    } else {
+      visitorsChart.data.labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+      visitorsChart.data.datasets[0].data = [5, 7, 6, 4, 3, 2, 8];
+      sourceChart.data.datasets[0].data = [50, 30, 20];
+    }
+    visitorsChart.update();
+    sourceChart.update();
+  };
+
+  if (applyBtn) {
+    applyBtn.addEventListener('click', window.updateAnalyticsCharts);
+  }
   applyTheme();
 
   if ('serviceWorker' in navigator) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,6 +4,7 @@ const ASSETS = [
   '/index.html',
   '/settings.html',
   '/reports.html',
+  '/analytics.html',
   '/users.html',
   '/style.css',
   '/script.js',

--- a/settings.html
+++ b/settings.html
@@ -18,7 +18,8 @@
       <li><a href="users.html"><span class="icon" aria-hidden="true">👥</span>Users</a></li>
       <li><a href="settings.html" class="active"><span class="icon" aria-hidden="true">⚙️</span>Settings</a></li>
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
-    </ul>
+      <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
+</ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">

--- a/users.html
+++ b/users.html
@@ -26,7 +26,8 @@
       <li><a href="users.html" class="active"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
-    </ul>
+      <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+</ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add new analytics.html page with Chart.js visuals
- integrate date range filter and chart updates in script.js
- link Analytics in navigation menus and cache it via service-worker
- document analytics behaviour in pages-plan

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f162966c8331ad229882f1064977