### PR TITLE
Add profile page with confirmation modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ The sidebar toggle appears on the right so it is reachable for right-handed mobi
 ## Theming
 
 Core colors are defined with CSS variables so both the dark and light themes stay consistent. The selected theme is stored in `localStorage` and applied early in the document head to prevent flashes of the wrong colors. Update `:root` variables in `style.css` to customize surface and border shades across the app.
+
+### Profile Page
+
+`profile.html` contains personal account controls. The form allows uploading a new avatar and changing the password. Submitting the form triggers a modal confirmation built with `openModal` in `script.js`.

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       <li><a href="index.html" class="active"><span class="icon">🏠</span>Dashboard</a></li>
       <li><a href="users.html"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
+      <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
 </ul>

--- a/profile.html
+++ b/profile.html
@@ -14,20 +14,20 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css" />
-  <title>Analytics</title>
+  <title>Profile</title>
 </head>
 <body>
   <script src="header.min.js"></script>
-  <script>buildHeader('Analytics');</script>
+  <script>buildHeader('Profile');</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>
-      <li><a href="index.html"><span class="icon">🏠</span>Dashboard</a></li>
-      <li><a href="users.html"><span class="icon">👥</span>Users</a></li>
-      <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
-      <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
-      <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
-      <li><a href="analytics.html" class="active"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="index.html"><span class="icon" aria-hidden="true">🏠</span>Dashboard</a></li>
+      <li><a href="users.html"><span class="icon" aria-hidden="true">👥</span>Users</a></li>
+      <li><a href="settings.html"><span class="icon" aria-hidden="true">⚙️</span>Settings</a></li>
+      <li><a href="profile.html" class="active"><span class="icon" aria-hidden="true">👤</span>Profile</a></li>
+      <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
+      <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
@@ -37,16 +37,21 @@
   </div>
   <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
-    <h2>Analytics</h2>
-    <div class="date-range">
-      <label>From <input type="date" id="start-date"></label>
-      <label>To <input type="date" id="end-date"></label>
-      <button id="apply-range" class="btn">Apply</button>
-    </div>
-    <canvas id="visitorsChart" width="400" height="200"></canvas>
-    <canvas id="sourceChart" width="300" height="200"></canvas>
+    <h2>Profile</h2>
+    <form id="profile-form">
+      <label>Avatar
+        <input id="avatar" type="file" accept="image/*" />
+      </label>
+      <label for="new-password">New Password
+        <input id="new-password" type="password" required />
+      </label>
+      <label for="confirm-password">Confirm Password
+        <input id="confirm-password" type="password" required />
+      </label>
+      <button type="submit" class="btn">Save</button>
+    </form>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <footer class="app-footer" role="contentinfo">v0.1</footer>
   <script src="script.js"></script>
 </body>

--- a/reports.html
+++ b/reports.html
@@ -25,6 +25,7 @@
       <li><a href="index.html"><span class="icon">🏠</span>Dashboard</a></li>
       <li><a href="users.html"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
+      <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
 </ul>

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@
   const filterInput = document.getElementById('user-filter');
   const addUserBtn = document.getElementById('add-user-btn');
   const form = document.getElementById('settings-form');
+  const profileForm = document.getElementById('profile-form');
   const toast = document.getElementById('toast');
   const chartCanvas = document.getElementById('reportChart');
 
@@ -187,6 +188,26 @@
     form.addEventListener('submit', (e) => {
       e.preventDefault();
       showToast('Settings saved');
+    });
+  }
+
+  if (profileForm) {
+    profileForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const html = `
+        <p>Save profile changes?</p>
+        <div class="modal-actions">
+          <button id="confirm-profile" class="btn">Yes</button>
+          <button id="cancel-profile" class="btn">Cancel</button>
+        </div>`;
+      openModal(html);
+      const confirmBtn = document.getElementById('confirm-profile');
+      const cancelBtn = document.getElementById('cancel-profile');
+      confirmBtn.addEventListener('click', () => {
+        closeModal();
+        showToast('Profile updated');
+      });
+      cancelBtn.addEventListener('click', closeModal);
     });
   }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,6 +3,7 @@ const ASSETS = [
   '/',
   '/index.html',
   '/settings.html',
+  '/profile.html',
   '/reports.html',
   '/analytics.html',
   '/users.html',

--- a/settings.html
+++ b/settings.html
@@ -17,6 +17,7 @@
       <li><a href="index.html"><span class="icon" aria-hidden="true">🏠</span>Dashboard</a></li>
       <li><a href="users.html"><span class="icon" aria-hidden="true">👥</span>Users</a></li>
       <li><a href="settings.html" class="active"><span class="icon" aria-hidden="true">⚙️</span>Settings</a></li>
+      <li><a href="profile.html"><span class="icon" aria-hidden="true">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
 </ul>

--- a/style.css
+++ b/style.css
@@ -401,3 +401,9 @@ html.light .filter-input {
   margin: 0 auto;
   width: 100%;
 }
+
+#profile-form {
+  max-width: 400px;
+  margin: 0 auto;
+  width: 100%;
+}

--- a/users.html
+++ b/users.html
@@ -25,6 +25,7 @@
       <li><a href="index.html"><span class="icon">🏠</span>Dashboard</a></li>
       <li><a href="users.html" class="active"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
+      <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
 </ul>


### PR DESCRIPTION
## Summary
- build profile page for avatar and password changes
- show modal confirmation for profile form submission
- link new page in navigation menus
- cache profile page via the service worker
- document profile page in README

## Testing
- `node --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f308408c8331a4d9a55cce612304