### PR TITLE
Add logs page and navigation

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html" class="active"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
-</ul>
+      <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
+    </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">

--- a/logs.html
+++ b/logs.html
@@ -14,21 +14,21 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css" />
-  <title>User Management</title>
+  <title>Logs</title>
 </head>
 <body>
   <script src="header.min.js"></script>
-  <script>buildHeader('User Management', {notifications: true});</script>
+  <script>buildHeader('Logs', {notifications: true});</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>
       <li><a href="index.html"><span class="icon">🏠</span>Dashboard</a></li>
-      <li><a href="users.html" class="active"><span class="icon">👥</span>Users</a></li>
+      <li><a href="users.html"><span class="icon">👥</span>Users</a></li>
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
-      <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
+      <li><a href="logs.html" class="active"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
@@ -38,10 +38,9 @@
   </div>
   <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
-    <h2>Users</h2>
-    <button id="add-user-btn" class="btn">Add User</button>
-    <label for="user-filter" class="sr-only">Filter users</label>
-    <input id="user-filter" type="text" class="filter-input" placeholder="Filter users" />
+    <h2>Audit Logs</h2>
+    <label for="user-filter" class="sr-only">Filter logs</label>
+    <input id="user-filter" type="text" class="filter-input" placeholder="Filter logs" />
     <div class="table-container" aria-live="polite">
       <div class="table-skeleton">
         <div class="skeleton-row"></div>
@@ -51,27 +50,21 @@
       <table id="user-table" class="data-table" hidden>
         <thead>
           <tr>
+            <th data-sort="time" class="sortable">Timestamp</th>
             <th data-sort="user" class="sortable">User</th>
-            <th data-sort="status" class="sortable">Status</th>
-            <th>Actions</th>
+            <th data-sort="action" class="sortable">Action</th>
           </tr>
         </thead>
         <tbody>
           <tr>
+            <td>2025-01-01 10:00</td>
             <td>Alice</td>
-            <td><span class="label success">Active</span></td>
-            <td>
-              <button class="btn edit-user-btn">Edit</button>
-              <button class="btn delete-user-btn">Delete</button>
-            </td>
+            <td>Logged in</td>
           </tr>
           <tr>
+            <td>2025-01-01 10:05</td>
             <td>Bob</td>
-            <td><span class="label danger">Suspended</span></td>
-            <td>
-              <button class="btn edit-user-btn">Edit</button>
-              <button class="btn delete-user-btn">Delete</button>
-            </td>
+            <td>Updated settings</td>
           </tr>
         </tbody>
       </table>

--- a/notifications.html
+++ b/notifications.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>

--- a/pages-plan.md
+++ b/pages-plan.md
@@ -38,5 +38,6 @@ This document outlines suggested content and improvements for each page in the a
 
 ## Future Pages
 - **Profile** – personal account settings and password changes.
+- **Logs** – audit trail page showing timestamp, user and action with sortable and filterable columns.
 
 These plans build on the existing checklist and keep the overall dark theme while adding more robust features.

--- a/profile.html
+++ b/profile.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html" class="active"><span class="icon" aria-hidden="true">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
+      <li><a href="logs.html"><span class="icon" aria-hidden="true">📜</span>Logs</a></li>
     </ul>
   </nav>
   <div id="overlay" class="overlay"></div>

--- a/reports.html
+++ b/reports.html
@@ -28,7 +28,8 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
-</ul>
+      <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
+    </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,6 +7,7 @@ const ASSETS = [
   '/reports.html',
   '/analytics.html',
   '/users.html',
+  '/logs.html',
   '/style.css',
   '/script.js',
   '/header.js'

--- a/settings.html
+++ b/settings.html
@@ -20,7 +20,8 @@
       <li><a href="profile.html"><span class="icon" aria-hidden="true">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
-</ul>
+      <li><a href="logs.html"><span class="icon" aria-hidden="true">📜</span>Logs</a></li>
+    </ul>
   </nav>
   <div id="overlay" class="overlay"></div>
   <div id="page-loader" class="page-loader" role="status" aria-live="polite" aria-hidden="true">


### PR DESCRIPTION
## Summary
- create `logs.html` with table for auditing
- link Logs page in sidebar navigation
- cache new page in service worker
- document log requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fa424774833186f5632805cd48df