### PR TITLE
Add tasks management page

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>

--- a/logs.html
+++ b/logs.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
       <li><a href="logs.html" class="active"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>

--- a/notifications.html
+++ b/notifications.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>

--- a/profile.html
+++ b/profile.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html" class="active"><span class="icon" aria-hidden="true">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon" aria-hidden="true">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon" aria-hidden="true">📜</span>Logs</a></li>
     </ul>
   </nav>

--- a/reports.html
+++ b/reports.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,9 @@
   const profileForm = document.getElementById('profile-form');
   const toast = document.getElementById('toast');
   const chartCanvas = document.getElementById('reportChart');
+  const taskForm = document.getElementById('task-form');
+  const taskInput = document.getElementById('task-input');
+  const taskTable = document.getElementById('task-table');
 
   window.showLoader = function () {
     if (pageLoader) pageLoader.classList.add('visible');
@@ -184,6 +187,10 @@
     });
   }
 
+  if (taskTable) {
+    initTasks();
+  }
+
   if (form) {
     form.addEventListener('submit', (e) => {
       e.preventDefault();
@@ -345,6 +352,60 @@
         cancel.addEventListener('click', () => {
           closeModal();
         });
+      });
+    }
+  };
+
+  const initTasks = () => {
+    if (!taskTable) return;
+    const tbody = taskTable.querySelector('tbody');
+
+    const attachHandlers = (row) => {
+      const edit = row.querySelector('.edit-task-btn');
+      if (edit) {
+        edit.addEventListener('click', () => {
+          const current = row.children[0].textContent.trim();
+          const html = `
+            <form id="edit-task-form">
+              <h3>Edit Task</h3>
+              <input id="edit-task-input" type="text" value="${current}" required />
+              <div class="modal-actions">
+                <button type="submit" class="btn">Save</button>
+                <button type="button" class="btn" id="cancel-edit-task">Cancel</button>
+              </div>
+            </form>`;
+          openModal(html);
+          const form = document.getElementById('edit-task-form');
+          const cancel = document.getElementById('cancel-edit-task');
+          form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            row.children[0].textContent = document.getElementById('edit-task-input').value;
+            closeModal();
+          });
+          cancel.addEventListener('click', closeModal);
+        });
+      }
+
+      const del = row.querySelector('.delete-task-btn');
+      if (del) {
+        del.addEventListener('click', () => {
+          row.remove();
+        });
+      }
+    };
+
+    Array.from(tbody.querySelectorAll('tr')).forEach(attachHandlers);
+
+    if (taskForm) {
+      taskForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const name = taskInput.value.trim();
+        if (!name) return;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${name}</td><td><button class="btn edit-task-btn">Edit</button> <button class="btn delete-task-btn">Delete</button></td>`;
+        tbody.appendChild(tr);
+        attachHandlers(tr);
+        taskForm.reset();
       });
     }
   };

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,6 +6,7 @@ const ASSETS = [
   '/profile.html',
   '/reports.html',
   '/analytics.html',
+  '/tasks.html',
   '/users.html',
   '/logs.html',
   '/style.css',

--- a/settings.html
+++ b/settings.html
@@ -20,6 +20,7 @@
       <li><a href="profile.html"><span class="icon" aria-hidden="true">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon" aria-hidden="true">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon" aria-hidden="true">📜</span>Logs</a></li>
     </ul>
   </nav>

--- a/style.css
+++ b/style.css
@@ -422,3 +422,19 @@ html.light .filter-input {
   margin: 0 auto;
   width: 100%;
 }
+
+#task-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  max-width: 400px;
+}
+
+#task-form input {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-color);
+  color: var(--text-color);
+}

--- a/tasks.html
+++ b/tasks.html
@@ -14,11 +14,11 @@
     })();
   </script>
   <link rel="stylesheet" href="style.css" />
-  <title>Analytics</title>
+  <title>Tasks</title>
 </head>
 <body>
   <script src="header.min.js"></script>
-  <script>buildHeader('Analytics', {notifications: true});</script>
+  <script>buildHeader('Tasks', {notifications: true});</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>
@@ -27,8 +27,8 @@
       <li><a href="settings.html"><span class="icon">⚙️</span>Settings</a></li>
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
-      <li><a href="analytics.html" class="active"><span class="icon">📈</span>Analytics</a></li>
-      <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="tasks.html" class="active"><span class="icon">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>
@@ -39,16 +39,30 @@
   </div>
   <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
-    <h2>Analytics</h2>
-    <div class="date-range">
-      <label>From <input type="date" id="start-date"></label>
-      <label>To <input type="date" id="end-date"></label>
-      <button id="apply-range" class="btn">Apply</button>
-    </div>
-    <canvas id="visitorsChart" width="400" height="200"></canvas>
-    <canvas id="sourceChart" width="300" height="200"></canvas>
+    <h2>Tasks</h2>
+    <form id="task-form" class="task-form">
+      <label for="task-input" class="sr-only">New task</label>
+      <input id="task-input" type="text" placeholder="New task" required />
+      <button type="submit" class="btn">Add</button>
+    </form>
+    <table id="task-table" class="data-table">
+      <thead>
+        <tr>
+          <th>Task</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Example Task</td>
+          <td>
+            <button class="btn edit-task-btn">Edit</button>
+            <button class="btn delete-task-btn">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <footer class="app-footer" role="contentinfo">v0.1</footer>
   <script src="script.js"></script>
 </body>

--- a/users.html
+++ b/users.html
@@ -28,6 +28,7 @@
       <li><a href="profile.html"><span class="icon">👤</span>Profile</a></li>
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
+      <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
## Summary
- add new `tasks.html` with task list and form
- style tasks with `#task-form` rules in `style.css`
- implement task add/edit/delete logic in `script.js`
- include tasks page in sidebar navigation
- cache tasks page via `service-worker.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842fba950e08331b48e9e69338d7fc5