### PR TITLE
Add calendar page

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html" class="active"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/calendar.html
+++ b/calendar.html
@@ -5,12 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#000" />
   <link rel="manifest" href="manifest.json" />
+  <script>
+    (function () {
+      const saved = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const light = saved === 'light' || (!saved && !prefersDark);
+      if (light) document.documentElement.classList.add('light');
+    })();
+  </script>
   <link rel="stylesheet" href="style.css" />
-  <title>Messages</title>
+  <title>Calendar</title>
 </head>
 <body>
   <script src="header.min.js"></script>
-  <script>buildHeader('Messages', {notifications: true});</script>
+  <script>buildHeader('Calendar', {notifications: true});</script>
   <nav id="sidebar" class="sidebar" role="navigation">
     <button id="sidebar-close" class="close-btn" aria-label="Close navigation">✖</button>
     <ul>
@@ -21,8 +29,8 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
-      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
-      <li><a href="messages.html" class="active"><span class="icon">💬</span>Messages</a></li>
+      <li><a href="calendar.html" class="active"><span class="icon">📅</span>Calendar</a></li>
+      <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>
       <li><a href="help.html"><span class="icon">❓</span>Help</a></li>
@@ -35,29 +43,28 @@
   </div>
   <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
-    <h2>Messages</h2>
-    <ul class="notifications-list">
-      <li>Alice: Hi there!</li>
-      <li>Bob: Welcome to the chat.</li>
-    </ul>
-    <form id="message-form" class="task-form">
-      <label for="message-input" class="sr-only">New message</label>
-      <input id="message-input" type="text" placeholder="Type a message" required />
-      <button type="submit" class="btn">Send</button>
-    </form>
-    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+    <h2>Calendar</h2>
+    <div class="calendar-controls">
+      <button id="calendar-prev" class="btn" aria-label="Previous month">&lt;</button>
+      <span id="calendar-month"></span>
+      <button id="calendar-next" class="btn" aria-label="Next month">&gt;</button>
+    </div>
+    <table id="calendar-table" class="data-table calendar-table">
+      <thead>
+        <tr>
+          <th>Sun</th>
+          <th>Mon</th>
+          <th>Tue</th>
+          <th>Wed</th>
+          <th>Thu</th>
+          <th>Fri</th>
+          <th>Sat</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
   </main>
   <footer class="app-footer" role="contentinfo">v0.1</footer>
   <script src="script.js"></script>
-  <script>
-    const form = document.getElementById('message-form');
-    if (form) {
-      form.addEventListener('submit', (e) => {
-        e.preventDefault();
-        showToast('Message sent');
-        form.reset();
-      });
-    }
-  </script>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/logs.html
+++ b/logs.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html" class="active"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/notifications.html
+++ b/notifications.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/profile.html
+++ b/profile.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon" aria-hidden="true">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon" aria-hidden="true">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon" aria-hidden="true">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/reports.html
+++ b/reports.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html" class="active"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,10 @@
   const taskForm = document.getElementById('task-form');
   const taskInput = document.getElementById('task-input');
   const taskTable = document.getElementById('task-table');
+  const calendarTable = document.getElementById('calendar-table');
+  const calendarMonth = document.getElementById('calendar-month');
+  const calendarPrev = document.getElementById('calendar-prev');
+  const calendarNext = document.getElementById('calendar-next');
 
   window.showLoader = function () {
     if (pageLoader) pageLoader.classList.add('visible');
@@ -189,6 +193,10 @@
 
   if (taskTable) {
     initTasks();
+  }
+
+  if (calendarTable) {
+    initCalendar();
   }
 
   if (form) {
@@ -408,6 +416,38 @@
         taskForm.reset();
       });
     }
+  };
+
+  const initCalendar = () => {
+    if (!calendarTable) return;
+    let current = new Date();
+    const tbody = calendarTable.querySelector('tbody');
+    const render = () => {
+      const year = current.getFullYear();
+      const month = current.getMonth();
+      calendarMonth.textContent = current.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+      const first = new Date(year, month, 1).getDay();
+      const days = new Date(year, month + 1, 0).getDate();
+      let html = '<tr>';
+      for (let i = 0; i < first; i++) html += '<td></td>';
+      for (let d = 1; d <= days; d++) {
+        if ((first + d - 1) % 7 === 0 && d !== 1) html += '</tr><tr>';
+        html += `<td>${d}</td>`;
+      }
+      html += '</tr>';
+      tbody.innerHTML = html;
+    };
+    if (calendarPrev)
+      calendarPrev.addEventListener('click', () => {
+        current.setMonth(current.getMonth() - 1);
+        render();
+      });
+    if (calendarNext)
+      calendarNext.addEventListener('click', () => {
+        current.setMonth(current.getMonth() + 1);
+        render();
+      });
+    render();
   };
 
   if (chartCanvas && window.Chart) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -7,6 +7,7 @@ const ASSETS = [
   '/reports.html',
   '/analytics.html',
   '/tasks.html',
+  '/calendar.html',
   '/users.html',
   '/logs.html',
   '/status.html',

--- a/settings.html
+++ b/settings.html
@@ -21,6 +21,7 @@
       <li><a href="reports.html"><span class="icon" aria-hidden="true">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon" aria-hidden="true">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon" aria-hidden="true">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon" aria-hidden="true">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon" aria-hidden="true">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/status.html
+++ b/status.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html" class="active"><span class="icon">✅</span>Status</a></li>

--- a/style.css
+++ b/style.css
@@ -438,3 +438,21 @@ html.light .filter-input {
   background: var(--surface-color);
   color: var(--text-color);
 }
+
+.calendar-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.calendar-table {
+  max-width: 300px;
+  margin: 1rem auto;
+}
+
+.calendar-table th,
+.calendar-table td {
+  text-align: center;
+}

--- a/tasks.html
+++ b/tasks.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html" class="active"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>

--- a/users.html
+++ b/users.html
@@ -29,6 +29,7 @@
       <li><a href="reports.html"><span class="icon">📊</span>Reports <span class="badge">3</span></a></li>
       <li><a href="analytics.html"><span class="icon">📈</span>Analytics</a></li>
       <li><a href="tasks.html"><span class="icon">📝</span>Tasks</a></li>
+      <li><a href="calendar.html"><span class="icon">📅</span>Calendar</a></li>
       <li><a href="messages.html"><span class="icon">💬</span>Messages</a></li>
       <li><a href="logs.html"><span class="icon">📜</span>Logs</a></li>
       <li><a href="status.html"><span class="icon">✅</span>Status</a></li>


### PR DESCRIPTION
## Summary
- add a simple calendar page
- include calendar navigation script
- link calendar in the sidebar
- adjust styles and service worker caching

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684304fc7d9c833186393f8f52e6a293