### PR TITLE
Add header.min.js to service worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -15,7 +15,9 @@ const ASSETS = [
   '/help.html',
   '/style.css',
   '/script.js',
-  '/header.js'
+  '/header.js',
+  '/header.min.js',
+  'https://cdn.jsdelivr.net/npm/chart.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- include `/header.min.js` in the list of assets cached by the service worker
- also cache the CDN `chart.js` file so charts work offline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68430c89d87483318639c3504dc2c48f