### PR TITLE
Fix sidebar icon alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,6 +181,8 @@ form > label {
 }
 
 .icon {
+  display: inline-flex;
+  align-items: center;
   margin-right: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- center icons in `.icon` class so sidebar links align properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68437323fe6483318f2998766014b0f1