### PR TITLE
Add table container wrapper

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -27,6 +27,7 @@
       <span id="calendar-month"></span>
       <button id="calendar-next" class="btn" aria-label="Next month">&gt;</button>
     </div>
+    <div class="table-container">
     <table id="calendar-table" class="data-table calendar-table">
       <thead>
         <tr>
@@ -41,6 +42,7 @@
       </thead>
       <tbody></tbody>
     </table>
+    </div>
   </main>
   <footer class="app-footer" role="contentinfo">v0.1</footer>
   <script src="script.js" defer></script>

--- a/status.html
+++ b/status.html
@@ -22,6 +22,7 @@
   <div id="modal" class="modal" aria-hidden="true"></div>
   <main id="main" class="main-content" role="main">
     <h2>System Status</h2>
+    <div class="table-container">
     <table class="data-table">
       <thead>
         <tr>
@@ -44,6 +45,7 @@
         </tr>
       </tbody>
     </table>
+    </div>
     <canvas id="uptimeChart" width="400" height="200"></canvas>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/style.css
+++ b/style.css
@@ -214,6 +214,8 @@ form > label {
 
 .table-container {
   margin: 1rem 0;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .data-table {

--- a/tasks.html
+++ b/tasks.html
@@ -27,6 +27,7 @@
       <input id="task-input" type="text" placeholder="New task" required />
       <button type="submit" class="btn">Add</button>
     </form>
+    <div class="table-container">
     <table id="task-table" class="data-table">
       <thead>
         <tr>
@@ -44,6 +45,7 @@
         </tr>
       </tbody>
     </table>
+    </div>
   </main>
   <footer class="app-footer" role="contentinfo">v0.1</footer>
   <script src="script.js" defer></script>


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for data tables
- wrap tables in calendar, status and tasks pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684379c02544833193b6bbd8395df306