### PR TITLE
Add API mock data and service worker mapping

### DIFF
--- a/api/logs.json
+++ b/api/logs.json
@@ -1,0 +1,5 @@
+[
+  {"time": "2024-05-06", "user": "Alice", "action": "Login"},
+  {"time": "2024-05-07", "user": "Bob", "action": "Upload"},
+  {"time": "2024-05-08", "user": "Charlie", "action": "Logout"}
+]

--- a/api/status.json
+++ b/api/status.json
@@ -1,0 +1,5 @@
+[
+  {"service": "API", "status": "Operational"},
+  {"service": "Database", "status": "Maintenance"},
+  {"service": "Website", "status": "Operational"}
+]

--- a/api/tasks.json
+++ b/api/tasks.json
@@ -1,0 +1,5 @@
+[
+  {"name": "Finish report"},
+  {"name": "Submit timesheet"},
+  {"name": "Fix bug"}
+]

--- a/api/users.json
+++ b/api/users.json
@@ -1,0 +1,5 @@
+[
+  {"name": "Alice", "status": "Active"},
+  {"name": "Bob", "status": "Suspended"},
+  {"name": "Charlie", "status": "Active"}
+]

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'admin-cache-v3';
+const CACHE_NAME = 'admin-cache-v4';
 const ASSETS = [
   './',
   './index.html',
@@ -19,6 +19,10 @@ const ASSETS = [
   './header.min.js',
   './sidebar.min.js',
   'https://cdn.jsdelivr.net/npm/chart.js'
+  , './api/users.json'
+  , './api/logs.json'
+  , './api/tasks.json'
+  , './api/status.json'
 ];
 
 self.addEventListener('install', event => {
@@ -30,14 +34,16 @@ self.addEventListener('fetch', event => {
   const { request } = event;
   const url = new URL(request.url);
   if (url.pathname.startsWith('/api/')) {
+    // Map /api/resource -> /api/resource.json stored in cache
+    if (!url.pathname.endsWith('.json')) {
+      const jsonUrl = `${url.origin}${url.pathname}.json`;
+      event.respondWith(
+        caches.match(jsonUrl).then(resp => resp || fetch(jsonUrl))
+      );
+      return;
+    }
     event.respondWith(
-      fetch(request)
-        .then(resp => {
-          const clone = resp.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
-          return resp;
-        })
-        .catch(() => caches.match(request))
+      caches.match(request).then(resp => resp || fetch(request))
     );
     return;
   }


### PR DESCRIPTION
## Summary
- add `api/` directory with sample JSON data
- cache API JSON in service worker and map `/api/*` requests to the JSON files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493dc72d7c8331be241d9d9f1cb188