### PR TITLE
Update dashboard metrics and sample data

### DIFF
--- a/api/users.json
+++ b/api/users.json
@@ -1,5 +1,12 @@
 [
   {"name": "Alice", "status": "Active"},
   {"name": "Bob", "status": "Suspended"},
-  {"name": "Charlie", "status": "Active"}
+  {"name": "Charlie", "status": "Active"},
+  {"name": "Dana", "status": "Active"},
+  {"name": "Eve", "status": "Suspended"},
+  {"name": "Frank", "status": "Active"},
+  {"name": "Grace", "status": "Active"},
+  {"name": "Heidi", "status": "Suspended"},
+  {"name": "Ivan", "status": "Active"},
+  {"name": "Judy", "status": "Active"}
 ]

--- a/index.html
+++ b/index.html
@@ -33,6 +33,14 @@
         <h3>Recent Activity</h3>
         <canvas id="activityChart" width="200" height="100"></canvas>
       </div>
+      <div class="metric-card">
+        <h3>Open Tasks</h3>
+        <p id="task-count" class="metric-value">0</p>
+      </div>
+      <div class="metric-card">
+        <h3>System Health</h3>
+        <p id="system-health" class="metric-value">0%</p>
+      </div>
     </div>
     <div class="dashboard-grid">
   <label for="user-filter" class="sr-only">Filter users</label>
@@ -60,6 +68,6 @@
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <footer class="app-footer" role="contentinfo">v0.1</footer>
-  <script type="module" src="main.min.js"></script>
+  <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/js/charts.js
+++ b/js/charts.js
@@ -86,7 +86,7 @@ export function initDashboardCharts(usersCanvas, activityCanvas) {
         labels: ['Active', 'Suspended'],
         datasets: [{
           backgroundColor: ['#3498db', '#e74c3c'],
-          data: [0, 0]
+          data: [8, 2]
         }]
       },
       options: { responsive: true, plugins: { legend: { display: false } } }

--- a/main.js
+++ b/main.js
@@ -30,6 +30,8 @@ const userCountEl = document.getElementById('user-count');
 const usersChartCanvas = document.getElementById('usersChart');
 const activityChartCanvas = document.getElementById('activityChart');
 const statusTable = document.getElementById("status-table");
+const taskCountEl = document.getElementById('task-count');
+const systemHealthEl = document.getElementById('system-health');
 
 export function showLoader() { if (pageLoader) pageLoader.classList.add('visible'); }
 export function hideLoader() { if (pageLoader) pageLoader.classList.remove('visible'); }
@@ -207,6 +209,17 @@ function updateUserMetrics() {
   const active = rows.filter(r => r.querySelector('td:nth-child(2) .label')?.textContent.trim() === 'Active').length;
   userCountEl.textContent = total;
   updateDashboardUserChart(active, total - active);
+}
+
+function updateTaskMetric(count) {
+  if (taskCountEl) taskCountEl.textContent = count;
+}
+
+function updateSystemHealthMetric(list) {
+  if (!systemHealthEl) return;
+  const operational = list.filter(s => s.status === 'Operational').length;
+  const percent = list.length ? Math.round((operational / list.length) * 100) : 0;
+  systemHealthEl.textContent = `${percent}%`;
 }
 
 function initTable() {
@@ -453,6 +466,12 @@ const endInput = document.getElementById('end-date');
 const applyBtn = document.getElementById('apply-range');
 initAnalyticsCharts(visitorsCanvas, sourceCanvas);
 initDashboardCharts(usersChartCanvas, activityChartCanvas);
+if (taskCountEl) {
+  fetch(`${API_BASE}/tasks`).then(res => res.json()).then(list => updateTaskMetric(list.length));
+}
+if (systemHealthEl) {
+  fetch(`${API_BASE}/status`).then(res => res.json()).then(updateSystemHealthMetric);
+}
 if (applyBtn) applyBtn.addEventListener('click', () => updateAnalyticsCharts(startInput, endInput));
 applyTheme();
 


### PR DESCRIPTION
## Summary
- add new metric cards for open tasks and system health
- connect metrics to API data in `main.js`
- tweak dashboard chart defaults for better variety
- populate `users.json` with more sample records
- load unminified script on the dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68493fcc87108331b5a53af9d5ac3b76