### PR TITLE
Populate task data and extend messages

### DIFF
--- a/api/tasks.json
+++ b/api/tasks.json
@@ -1,5 +1,14 @@
 [
   {"name": "Finish report"},
   {"name": "Submit timesheet"},
-  {"name": "Fix bug"}
+  {"name": "Fix bug"},
+  {"name": "Review pull request"},
+  {"name": "Update documentation"},
+  {"name": "Plan sprint"},
+  {"name": "Refactor code"},
+  {"name": "Meet with team"},
+  {"name": "Deploy update"},
+  {"name": "Test new feature"},
+  {"name": "Resolve ticket"},
+  {"name": "Backup database"}
 ]

--- a/messages.html
+++ b/messages.html
@@ -25,6 +25,14 @@
     <ul class="notifications-list">
       <li>Alice: Hi there!</li>
       <li>Bob: Welcome to the chat.</li>
+      <li>Alice: How's it going?</li>
+      <li>Bob: Pretty good, thanks.</li>
+      <li>Alice: Did you finish the report?</li>
+      <li>Bob: Yes, I'll send it over.</li>
+      <li>Alice: Great! I'll review it.</li>
+      <li>Bob: Sounds good.</li>
+      <li>Alice: Let's plan the next meeting.</li>
+      <li>Bob: Sure, I'll set up a time.</li>
     </ul>
     <form id="message-form" class="task-form">
       <label for="message-input" class="sr-only">New message</label>


### PR DESCRIPTION
## Summary
- expand `tasks.json` with more sample tasks
- add more chat entries in `messages.html`

## Testing
- `node - <<'NODE'
const tasks = require('./api/tasks.json');
const perPage = 5;
console.log('tasks', tasks.length, 'pages', Math.ceil(tasks.length/perPage));
NODE`
- `grep -n "<li>" -n messages.html | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6849425f4780833184c1a200a54b5ecb