### PR TITLE
Update service worker API path check

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -35,17 +35,13 @@ self.addEventListener('install', event => {
 self.addEventListener('fetch', event => {
   const { request } = event;
   const url = new URL(request.url);
-  if (url.pathname.startsWith('/api/')) {
-    // Map /api/resource -> /api/resource.json stored in cache
-    if (!url.pathname.endsWith('.json')) {
-      const jsonUrl = `${url.origin}${url.pathname}.json`;
-      event.respondWith(
-        caches.match(jsonUrl).then(resp => resp || fetch(jsonUrl))
-      );
-      return;
-    }
+  if (url.pathname.includes('/api/')) {
+    const jsonPath = url.pathname.endsWith('.json')
+      ? url.pathname
+      : `${url.pathname}.json`;
+    const jsonUrl = `${url.origin}${jsonPath}`;
     event.respondWith(
-      caches.match(request).then(resp => resp || fetch(request))
+      caches.match(jsonUrl).then(resp => resp || fetch(jsonUrl))
     );
     return;
   }


### PR DESCRIPTION
## Summary
- broaden API path check in the service worker to work from any hosting path
- keep mapping `/api/resource` to `/api/resource.json`

## Testing
- `npx serve -l 5000` *(hit `/Codex-v3/api/users.json` via curl)*

------
https://chatgpt.com/codex/tasks/task_e_68494c0124308331b4dcf7ab42c4de46