### PR TITLE
Add more demo data and pagination

### DIFF
--- a/api/events.json
+++ b/api/events.json
@@ -4,4 +4,10 @@
   {"date": "2025-06-12", "title": "Release v1.0"},
   {"date": "2025-06-20", "title": "Board meeting"},
   {"date": "2025-06-25", "title": "Hackathon"}
+  ,{"date": "2025-07-01", "title": "Quarterly review"}
+  ,{"date": "2025-07-10", "title": "Security audit"}
+  ,{"date": "2025-07-15", "title": "Client workshop"}
+  ,{"date": "2025-07-22", "title": "Product demo"}
+  ,{"date": "2025-07-30", "title": "Company picnic"}
+  ,{"date": "2025-08-05", "title": "Budget planning"}
 ]

--- a/api/notifications.json
+++ b/api/notifications.json
@@ -3,5 +3,10 @@
   "New policy update available",
   "Server restarted",
   "Backup completed successfully",
-  "New user registered"
+  "New user registered",
+  "Database migration at 3PM",
+  "Password expires soon",
+  "Update your profile information",
+  "Maintenance window tomorrow",
+  "New comment on report"
 ]

--- a/api/status.json
+++ b/api/status.json
@@ -3,5 +3,11 @@
   {"service": "Database", "status": "Maintenance"},
   {"service": "Website", "status": "Operational"},
   {"service": "Auth", "status": "Operational"},
-  {"service": "Storage", "status": "Degraded"}
+  {"service": "Storage", "status": "Degraded"},
+  {"service": "Cache", "status": "Operational"},
+  {"service": "Email", "status": "Operational"},
+  {"service": "Search", "status": "Degraded"},
+  {"service": "Analytics", "status": "Operational"},
+  {"service": "Payments", "status": "Maintenance"},
+  {"service": "Messaging", "status": "Operational"}
 ]

--- a/api/tasks.json
+++ b/api/tasks.json
@@ -10,5 +10,8 @@
   {"name": "Deploy update"},
   {"name": "Test new feature"},
   {"name": "Resolve ticket"},
-  {"name": "Backup database"}
+  {"name": "Backup database"},
+  {"name": "Optimize queries"},
+  {"name": "Design mockups"},
+  {"name": "Conduct training"}
 ]

--- a/api/users.json
+++ b/api/users.json
@@ -8,5 +8,9 @@
   {"name": "Grace", "status": "Active"},
   {"name": "Heidi", "status": "Suspended"},
   {"name": "Ivan", "status": "Active"},
-  {"name": "Judy", "status": "Active"}
+  {"name": "Judy", "status": "Active"},
+  {"name": "Kevin", "status": "Active"},
+  {"name": "Laura", "status": "Suspended"},
+  {"name": "Mallory", "status": "Active"},
+  {"name": "Niaj", "status": "Active"}
 ]

--- a/status.html
+++ b/status.html
@@ -33,6 +33,7 @@
       <tbody>
         </tbody>
     </table>
+    <div class="table__pagination"></div>
     </div>
     <canvas id="uptimeChart" width="400" height="200"></canvas>
   </main>


### PR DESCRIPTION
## Summary
- add several sample users, tasks, events and status entries
- extend notifications for realistic badge updates
- insert pagination controls in `status.html`

## Testing
- `jq . api/users.json`
- `jq . api/tasks.json`
- `jq . api/status.json`
- `jq . api/events.json`
- `jq . api/logs.json`
- `jq . api/notifications.json`


------
https://chatgpt.com/codex/tasks/task_e_68495342858883318d38edc17a44431d