### PR TITLE
Add footer builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Include the script before your page content and call the function:
 </script>
 ```
 
+Include the footer script similarly and call `buildFooter()` to append a footer:
+
+```html
+<script src="footer.min.js"></script>
+<script>buildFooter('v0.1');</script>
+```
+
 The sidebar toggle appears on the right so it is reachable for right-handed mobile use. The header also includes a skip link for accessibility and optional theme toggle support.
 ## Sidebar Component
 

--- a/analytics.html
+++ b/analytics.html
@@ -31,7 +31,8 @@
     <canvas id="sourceChart" width="300" height="200"></canvas>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/calendar.html
+++ b/calendar.html
@@ -44,7 +44,8 @@
     </table>
     </div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/footer.js
+++ b/footer.js
@@ -1,0 +1,9 @@
+(function(){
+  window.buildFooter = function(text){
+    const footer = document.createElement('footer');
+    footer.className = 'app-footer';
+    footer.setAttribute('role','contentinfo');
+    footer.textContent = text;
+    document.body.appendChild(footer);
+  };
+})();

--- a/footer.min.js
+++ b/footer.min.js
@@ -1,0 +1,1 @@
+!function(){window.buildFooter=function(t){const e=document.createElement("footer");e.className="app-footer",e.setAttribute("role","contentinfo"),e.textContent=t,document.body.appendChild(e)}}();

--- a/help.html
+++ b/help.html
@@ -40,7 +40,8 @@
       </ul>
     </section>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,8 @@
 </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/logs.html
+++ b/logs.html
@@ -44,7 +44,8 @@
       <div class="table__pagination"></div>
     </div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/messages.html
+++ b/messages.html
@@ -41,7 +41,8 @@
     </form>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
   <script>
     const form = document.getElementById('message-form');

--- a/notifications.html
+++ b/notifications.html
@@ -24,7 +24,8 @@
     <h2>Notifications</h2>
     <ul id="notifications-list" class="notifications-list"></ul>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -36,7 +36,8 @@
     </form>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/reports.html
+++ b/reports.html
@@ -31,7 +31,8 @@
     <canvas id="reportChart" width="400" height="200"></canvas>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -17,6 +17,8 @@ const ASSETS = [
   './main.min.js',
   './header.js',
   './header.min.js',
+  './footer.js',
+  './footer.min.js',
   './sidebar.min.js',
   'https://cdn.jsdelivr.net/npm/chart.js'
   , './api/users.json'

--- a/settings.html
+++ b/settings.html
@@ -33,7 +33,8 @@
     </form>
     <div id="toast" class="toast" role="status" aria-live="polite"></div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/status.html
+++ b/status.html
@@ -38,7 +38,8 @@
     <canvas id="uptimeChart" width="400" height="200"></canvas>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
   <script>
     const ctx = document.getElementById('uptimeChart');

--- a/tasks.html
+++ b/tasks.html
@@ -41,7 +41,8 @@
     <div class="table__pagination"></div>
     </div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>

--- a/users.html
+++ b/users.html
@@ -45,7 +45,8 @@
       <div class="table__pagination"></div>
     </div>
   </main>
-  <footer class="app-footer" role="contentinfo">v0.1</footer>
+  <script src="footer.min.js"></script>
+  <script>buildFooter('v0.1');</script>
   <script type="module" src="main.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a footer builder module
- include footer module in all pages
- cache footer scripts via service worker
- document how to use the footer script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a34283a1c833193ddc9fba6acb83e